### PR TITLE
feat: duplicate textures on greedy meshes

### DIFF
--- a/Assets/Rivy X3/Data/Shader/VoxelShader.shader
+++ b/Assets/Rivy X3/Data/Shader/VoxelShader.shader
@@ -9,6 +9,8 @@ Shader "RX3/VoxelShader"
         [MainColor] _BaseColor("BaseColor", Color) = (1,1,1,1)
         [MainTexture] _BaseColorMap("BaseColorMap", 2D) = "white" {}
 
+        _AtlasCellSize("Atlas Cell Size", Vector) = (1,1,0,0)
+
         _Metallic("_Metallic", Range(0.0, 1.0)) = 0
         _Smoothness("Smoothness", Range(0.0, 1.0)) = 0.5
         _MaskMap("MaskMap", 2D) = "white" {}

--- a/Assets/Rivy X3/Data/Shader/hlsl/VoxelLitData.hlsl
+++ b/Assets/Rivy X3/Data/Shader/hlsl/VoxelLitData.hlsl
@@ -219,6 +219,13 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     ZERO_INITIALIZE(LayerTexCoord, layerTexCoord);
     GetLayerTexCoord(input, layerTexCoord);
 
+    float2 _cellSize = _AtlasCellSize.xy;
+    float2 _localUV = input.texCoord0.xy;
+    float2 _atlasIndex = input.texCoord1.xy;
+    layerTexCoord.base.uv = _atlasIndex * _cellSize + frac(_localUV) * _cellSize;
+    layerTexCoord.base.dudx = ddx(_localUV) * _cellSize;
+    layerTexCoord.base.dudy = ddy(_localUV) * _cellSize;
+
 #if !defined(SHADER_STAGE_RAY_TRACING)
     float depthOffset = ApplyPerPixelDisplacement(input, V, layerTexCoord);
     #ifdef _DEPTHOFFSET_ON

--- a/Assets/Rivy X3/Scripts/Block/ChunkSquareFaces.cs
+++ b/Assets/Rivy X3/Scripts/Block/ChunkSquareFaces.cs
@@ -2,7 +2,6 @@
 using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
-using static Atlas;
 
 namespace Assets.Scripts.Block
 {
@@ -95,22 +94,22 @@ namespace Assets.Scripts.Block
             trianglesList.AddNoResize(index + 3);
         }
 
-        public void GetUVs(ref NativeList<float2> uvsList, AtlasData atlasData)
+        public void GetUVs(ref NativeList<float2> uvsList, ref NativeList<float2> uv2List)
         {
-            float cellWidth = atlasData.CellWidthUV;
-            float cellHeight = atlasData.CellHeightUV;
-
             uint2 atlasIndex = Utils.IDToAtlasIndex((EnumData.BlocksID)id);
 
-            float uMin = atlasIndex.x * cellWidth;
-            float uMax = uMin + cellWidth;
-            float vMin = atlasIndex.y * cellHeight;
-            float vMax = vMin + cellHeight;
+            // UVs for tiling within the shader
+            uvsList.AddNoResize(new float2(0f, 0f));
+            uvsList.AddNoResize(new float2(this.sizeW, 0f));
+            uvsList.AddNoResize(new float2(this.sizeW, this.sizeH));
+            uvsList.AddNoResize(new float2(0f, this.sizeH));
 
-            uvsList.AddNoResize(new float2(uMin, vMin)); // Bottom-left
-            uvsList.AddNoResize(new float2(uMax, vMin)); // Bottom-right
-            uvsList.AddNoResize(new float2(uMax, vMax)); // Top-right
-            uvsList.AddNoResize(new float2(uMin, vMax)); // Top-left
+            // Secondary UV set stores the atlas index for the shader
+            float2 index = new float2(atlasIndex.x, atlasIndex.y);
+            uv2List.AddNoResize(index);
+            uv2List.AddNoResize(index);
+            uv2List.AddNoResize(index);
+            uv2List.AddNoResize(index);
         }
 
     }

--- a/Assets/Rivy X3/Scripts/Voxel/VoxelRegion.cs
+++ b/Assets/Rivy X3/Scripts/Voxel/VoxelRegion.cs
@@ -10,7 +10,6 @@ using Unity.Transforms;
 using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.Rendering;
-using static Atlas;
 using static EnumData;
 using static UnityEngine.EventSystems.EventTrigger;
 using static UnityEngine.Rendering.HighDefinition.ScalableSettingLevelParameter;
@@ -418,9 +417,6 @@ public static class VoxelRegion
     public static void GenerateMesh(ref EntityManager entityManager, Entity regionEntity, int3 regionCoord, WorldSettings WS)
     {
 
-        // Get atlas //
-        AtlasData atlas = VoxelWorld._Instance._Atlas;
-
         // Get the region buffer //
         DynamicBuffer<RegionChunks> chunksBuffer = entityManager.GetBuffer<RegionChunks>(regionEntity);
 
@@ -436,6 +432,7 @@ public static class VoxelRegion
         NativeList<float3> verticesList = new NativeList<float3>(totalFaces * 4, Allocator.Temp);
         NativeList<int> trianglesList = new NativeList<int>(totalFaces * 6, Allocator.Temp);
         NativeList<float2> uvsList = new NativeList<float2>(totalFaces * 4, Allocator.Temp);
+        NativeList<float2> uv2List = new NativeList<float2>(totalFaces * 4, Allocator.Temp);
 
         // Itinerate all chunks //
         foreach(RegionChunks chunk in chunksBuffer)
@@ -465,7 +462,7 @@ public static class VoxelRegion
                     int startIndex = verticesList.Length;
                     squareFace.GetSquare(ref verticesList, offset);
                     squareFace.GetTriangles(startIndex, ref trianglesList);
-                    squareFace.GetUVs(ref uvsList, atlas);
+                    squareFace.GetUVs(ref uvsList, ref uv2List);
                 }
             }
 
@@ -480,6 +477,7 @@ public static class VoxelRegion
         mesh.SetVertices(verticesList.AsArray());
         mesh.SetIndices(trianglesList.AsArray(), MeshTopology.Triangles, 0);
         mesh.SetUVs(0, uvsList.AsArray());
+        mesh.SetUVs(1, uv2List.AsArray());
         mesh.RecalculateNormals();
         mesh.RecalculateBounds();
         mesh.UploadMeshData(false);
@@ -491,6 +489,7 @@ public static class VoxelRegion
         verticesList.Dispose();
         trianglesList.Dispose();
         uvsList.Dispose();
+        uv2List.Dispose();
 
 
 

--- a/Assets/Rivy X3/Scripts/Voxel/VoxelWorld.cs
+++ b/Assets/Rivy X3/Scripts/Voxel/VoxelWorld.cs
@@ -98,6 +98,10 @@ public class VoxelWorld : MonoBehaviour
         // Save the instance //
         _Instance = this;
 
+        // Send atlas cell size to shader
+        AtlasData atlasData = this._Atlas;
+        Shader.SetGlobalVector("_AtlasCellSize", new Vector4(atlasData.CellWidthUV, atlasData.CellHeightUV, 0f, 0f));
+
         // Create the chunks manager //
         if (this.ChunkSManager != null)
             GameObject.DestroyImmediate(this.ChunkSManager.gameObject);


### PR DESCRIPTION
## Summary
- add second UV set for atlas index and local tiling
- compute atlas UVs in shader to repeat textures instead of stretching
- send atlas cell size to shader from VoxelWorld

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b577b90083299f1200de25ac6e11