### PR TITLE
Remove vertical chunk streaming parameter

### DIFF
--- a/Assets/Rivy X3/Scenes/Main.unity
+++ b/Assets/Rivy X3/Scenes/Main.unity
@@ -666,7 +666,6 @@ MonoBehaviour:
   maxRegionDistance: 8
   nearRegionDistance: 1
   playerContactRegionDistance: 1
-  yViewDistance: 4
   regionSize: 6
   yRegionSize: 4
   chunkSize: 16

--- a/Assets/Rivy X3/Scripts/Static/ChunksPoolManager.cs
+++ b/Assets/Rivy X3/Scripts/Static/ChunksPoolManager.cs
@@ -30,7 +30,7 @@ public partial struct ChunksPoolManagerSystem : ISystem
         this.chunkArchetype = em.CreateArchetype(typeof(ChunkPosition), typeof(LocalTransform), typeof(ChunkNeedBlocks), typeof(ChunkNeedRender), typeof(BlockData), typeof(ChunkSquareFaces));
 
         //// Create all chunks //
-        //int regions = ((world.maxRegionDistance*2)+1) * ((world.maxRegionDistance * 2) + 1) * (world.yViewDistance + 2);
+        //int regions = ((world.maxRegionDistance * 2) + 1) * ((world.maxRegionDistance * 2) + 1);
         //int chunksToCreate = regions * world.regionSizeInChunks;
         //chunksToCreate = (int)(chunksToCreate * 1.2f);
         //NativeArray<Entity> chunkArray = new NativeArray<Entity>(chunksToCreate, Allocator.Temp);

--- a/Assets/Rivy X3/Scripts/Static/SingletonManager.cs
+++ b/Assets/Rivy X3/Scripts/Static/SingletonManager.cs
@@ -24,7 +24,6 @@ public struct WorldSettings : IComponentData
     public int maxRegionDistance;
     public int nearRegionDistance;
     public int playerContactRegionDistance;
-    public int yViewDistance;
 
     public int chunkBlocksCount;
     public int regionSizeInChunks;
@@ -144,7 +143,6 @@ public partial struct SingletonManager : ISystem
             maxRegionDistance = world.maxRegionDistance,
             nearRegionDistance = world.nearRegionDistance,
             playerContactRegionDistance = world.playerContactRegionDistance,
-            yViewDistance = world.yViewDistance,
 
             chunkBlocksCount = world.chunkBlocksCount,
             regionSizeInChunks = world.regionSizeInChunks,

--- a/Assets/Rivy X3/Scripts/Voxel/VoxelRegion.cs
+++ b/Assets/Rivy X3/Scripts/Voxel/VoxelRegion.cs
@@ -167,40 +167,38 @@ public partial struct RegionManagerSystem : ISystem
 
         // Get the player coord //
         int3 playerCoord = Utils.WorldPosToRegionCoord(Camera.main.transform.position, WS.regionSize * WS.chunkSize, WS.yRegionSize * WS.yChunkSize);
+        playerCoord.y = 0;
 
         // Create the nativeList //
         NativeList<RegionsInfo> regionsToCreate = new NativeList<RegionsInfo>(Allocator.Temp);
 
         // Check all regions around //
         for (int dx = -WS.maxRegionDistance; dx <= WS.maxRegionDistance; dx++)
-            for (int dy = -WS.yViewDistance; dy <= WS.yViewDistance; dy++)
-                for (int dz = -WS.maxRegionDistance; dz <= WS.maxRegionDistance; dz++)
+            for (int dz = -WS.maxRegionDistance; dz <= WS.maxRegionDistance; dz++)
+            {
+
+                // Get the region coord //
+                int3 regionCoord = playerCoord + new int3(dx, 0, dz);
+
+                // Get the distance //
+                float distance = 0;
+
+                // Cubic or spheric generation //
+                if (WS.sphericChunkGeneration == false)
                 {
-
-                    // Get the region coord //
-                    int3 regionCoord = playerCoord + new int3(dx, dy, dz);
-
-                    // Get the distance //
-                    float distance = 0;
-
-                    // Cubic or spheric generation //
-                    if (WS.sphericChunkGeneration == false)
-                    {
-                        int adx = math.abs(regionCoord.x - playerCoord.x);
-                        int ady = math.abs(regionCoord.y - playerCoord.y) * WS.yRegionSize / WS.regionSize;
-                        int adz = math.abs(regionCoord.z - playerCoord.z);
-                        distance = math.max(math.max(adx, ady), adz);
-                    }
-                    else
-                    {
-                        distance = math.sqrt(
-                            dx * dx +
-                            dz * dz +
-                            math.pow(dy * WS.yRegionSize / WS.regionSize, 2)
-                        );
-                        if (distance > WS.maxRegionDistance)
-                            continue;
-                    }
+                    int adx = math.abs(regionCoord.x - playerCoord.x);
+                    int adz = math.abs(regionCoord.z - playerCoord.z);
+                    distance = math.max(adx, adz);
+                }
+                else
+                {
+                    distance = math.sqrt(
+                        dx * dx +
+                        dz * dz
+                    );
+                    if (distance > WS.maxRegionDistance)
+                        continue;
+                }
 
 
                     // Get the wanted LOD //
@@ -240,25 +238,16 @@ public partial struct RegionManagerSystem : ISystem
             if (WS.sphericChunkGeneration == false)
             {
                 if (math.abs(coord.ValueRO.Value.x - playerCoord.x) > WS.maxRegionDistance
-                || math.abs(coord.ValueRO.Value.z - playerCoord.z) > WS.maxRegionDistance
-                || math.abs(coord.ValueRO.Value.y - playerCoord.y) > WS.yViewDistance)
+                || math.abs(coord.ValueRO.Value.z - playerCoord.z) > WS.maxRegionDistance)
                     outsideDistance = true;
             }
             else
             {
-                if (math.abs(coord.ValueRO.Value.y - playerCoord.y) > WS.yViewDistance)
-                {
+                float dx = coord.ValueRO.Value.x - playerCoord.x;
+                float dz = coord.ValueRO.Value.z - playerCoord.z;
+                float dist2D = math.sqrt(dx * dx + dz * dz);
+                if (dist2D > WS.maxRegionDistance)
                     outsideDistance = true;
-                }
-                else
-                {
-                    float dx = coord.ValueRO.Value.x - playerCoord.x;
-                    float dz = coord.ValueRO.Value.z - playerCoord.z;
-                    float dy = (coord.ValueRO.Value.y - playerCoord.y) * WS.yRegionSize / WS.regionSize;
-                    float dist3D = math.sqrt(dx * dx + dz * dz + dy * dy);
-                    if (dist3D > WS.maxRegionDistance)
-                        outsideDistance = true;
-                }
             }
 
             // Check if the region is outside of the distance //

--- a/Assets/Rivy X3/Scripts/Voxel/VoxelWorld.cs
+++ b/Assets/Rivy X3/Scripts/Voxel/VoxelWorld.cs
@@ -38,7 +38,6 @@ public class VoxelWorld : MonoBehaviour
     public int maxRegionDistance = 5;
     public int nearRegionDistance = 3;
     public int playerContactRegionDistance = 1;
-    public int yViewDistance = 2;
 
     public int regionSize = 4;
     public int yRegionSize = 16;


### PR DESCRIPTION
## Summary
- remove `yViewDistance` configuration and related logic
- limit region management to a single vertical layer
- clean up scene and comments referencing vertical streaming

## Testing
- `dotnet build 'Rivy X3.sln'` *(fails: The reference assemblies for .NETFramework,Version=v4.7.1 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d977d9ac832993aaa56f45806b9c